### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/run_script_kabutan.yml
+++ b/.github/workflows/run_script_kabutan.yml
@@ -5,6 +5,10 @@ on:
   schedule:
     - cron: '0 9 * * *'
 
+permissions:
+  contents: read
+  actions: read
+
 jobs:
   run_script:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/aegisfleet/markets-trending-to-bluesky/security/code-scanning/5](https://github.com/aegisfleet/markets-trending-to-bluesky/security/code-scanning/5)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimal permissions required for the workflow to function correctly. Based on the actions used in the workflow, the following permissions are appropriate:
- `contents: read` for checking out the repository.
- `actions: read` for downloading and uploading artifacts.

The `permissions` block should be added at the root level of the workflow to apply to all jobs, as there is only one job (`run_script`) in this workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
