### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/run_script_minkabu.yml
+++ b/.github/workflows/run_script_minkabu.yml
@@ -5,6 +5,9 @@ on:
   schedule:
     - cron: '0 20 * * *'
 
+permissions:
+  contents: read
+
 jobs:
   run_script:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/aegisfleet/markets-trending-to-bluesky/security/code-scanning/4](https://github.com/aegisfleet/markets-trending-to-bluesky/security/code-scanning/4)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Based on the workflow's actions, the `contents: read` permission is sufficient for checking out the repository and downloading artifacts. No write permissions are required since the workflow does not modify repository contents or create pull requests.

The `permissions` block can be added at the root level of the workflow to apply to all jobs, or specifically to the `run_script` job. In this case, adding it at the root level is more concise and ensures consistency across all jobs.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
