### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/run_script_nikkei.yml
+++ b/.github/workflows/run_script_nikkei.yml
@@ -1,4 +1,6 @@
 name: スクリプトを実行する(日経)
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/aegisfleet/markets-trending-to-bluesky/security/code-scanning/3](https://github.com/aegisfleet/markets-trending-to-bluesky/security/code-scanning/3)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the least privileges required for the workflow to function. Based on the provided steps, the workflow primarily interacts with the repository to check out code and install dependencies. Therefore, it only requires `contents: read` permission. No write permissions are necessary.

The `permissions` block will be added after the `name` field and before the `on` field in the workflow file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
