### PR TITLE
Potential fix for code scanning alert no. 9: Artifact poisoning

### DIFF
--- a/.github/workflows/run_script_kabutan.yml
+++ b/.github/workflows/run_script_kabutan.yml
@@ -12,20 +12,22 @@ permissions:
 jobs:
   run_script:
     runs-on: ubuntu-latest
+    env:
+      ARTIFACT_DIR: ${{ runner.temp }}/artifacts/kabutan
 
     steps:
       - name: リポジトリをチェックアウト
         uses: actions/checkout@v6
 
       - name: 成果物用の一時ディレクトリを作成
-        run: mkdir -p "${{ runner.temp }}/artifacts/kabutan"
+        run: mkdir -p "${ARTIFACT_DIR}"
 
       - name: 前回の成果物をダウンロード
         uses: dawidd6/action-download-artifact@v21
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           name: artifact
-          path: ${{ runner.temp }}/artifacts/kabutan
+          path: ${{ env.ARTIFACT_DIR }}
           if_no_artifact_found: ignore
 
       - name: Pythonの実行環境をセットアップ
@@ -49,5 +51,5 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: artifact
-          path: ${{ runner.temp }}/artifacts/kabutan/
+          path: ${{ env.ARTIFACT_DIR }}/
           retention-days: 10

--- a/.github/workflows/run_script_kabutan.yml
+++ b/.github/workflows/run_script_kabutan.yml
@@ -17,12 +17,15 @@ jobs:
       - name: リポジトリをチェックアウト
         uses: actions/checkout@v6
 
+      - name: 成果物用の一時ディレクトリを作成
+        run: mkdir -p "${{ runner.temp }}/artifacts/kabutan"
+
       - name: 前回の成果物をダウンロード
         uses: dawidd6/action-download-artifact@v21
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           name: artifact
-          path: tmp
+          path: ${{ runner.temp }}/artifacts/kabutan
           if_no_artifact_found: ignore
 
       - name: Pythonの実行環境をセットアップ
@@ -46,5 +49,5 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: artifact
-          path: tmp/
+          path: ${{ runner.temp }}/artifacts/kabutan/
           retention-days: 10

--- a/.github/workflows/run_script_minkabu.yml
+++ b/.github/workflows/run_script_minkabu.yml
@@ -12,17 +12,22 @@ permissions:
 jobs:
   run_script:
     runs-on: ubuntu-latest
+    env:
+      ARTIFACT_DIR: ${{ runner.temp }}/artifacts/minkabu
 
     steps:
       - name: リポジトリをチェックアウト
         uses: actions/checkout@v6
+
+      - name: 成果物用の一時ディレクトリを作成
+        run: mkdir -p "${ARTIFACT_DIR}"
 
       - name: 前回の成果物をダウンロード
         uses: dawidd6/action-download-artifact@v21
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           name: artifact
-          path: tmp
+          path: ${{ env.ARTIFACT_DIR }}
           if_no_artifact_found: ignore
 
       - name: Pythonの実行環境をセットアップ
@@ -46,5 +51,5 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: artifact
-          path: tmp/
+          path: ${{ env.ARTIFACT_DIR }}/
           retention-days: 10

--- a/artifact_utils.py
+++ b/artifact_utils.py
@@ -1,7 +1,12 @@
 import os
 
+
+def _artifact_dir():
+    return os.environ.get("ARTIFACT_DIR", "tmp")
+
+
 def save_results(models):
-    folder_path = "tmp"
+    folder_path = _artifact_dir()
     file_path = os.path.join(folder_path, "previous_result.txt")
 
     if not os.path.exists(folder_path):
@@ -11,8 +16,9 @@ def save_results(models):
         for model in models:
             file.write(f"{model[0]}\n")
 
+
 def load_previous_results():
-    folder_path = "tmp"
+    folder_path = _artifact_dir()
     file_path = os.path.join(folder_path, "previous_result.txt")
 
     try:


### PR DESCRIPTION
Potential fix for [https://github.com/aegisfleet/markets-trending-to-bluesky/security/code-scanning/9](https://github.com/aegisfleet/markets-trending-to-bluesky/security/code-scanning/9)

対策の基本は、**ダウンロード成果物をワークスペース外の一時領域（`${{ runner.temp }}`）に隔離し、必要に応じて検証後にのみ利用する**ことです。  
このファイルでは、以下の最小変更が最適です（既存機能を変えずに安全性を向上）:

1. 成果物ダウンロード前に一時ディレクトリを作成するステップを追加。
2. `dawidd6/action-download-artifact` の `path` を `tmp` から `${{ runner.temp }}/artifacts/kabutan` に変更。
3. アップロード対象も同じ隔離パスに変更して、次回実行でも同じ安全な保存先を利用。

変更対象は **`.github/workflows/run_script_kabutan.yml` の成果物ダウンロード/アップロード周辺（20行目付近、45行目付近）** です。新規依存や追加 import は不要です。


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
