### PR TITLE
fix: upgrade cryptography to >=50.0.0 (CVE-2026-69247)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,6 @@ dependencies = [
 
 [tool.uv]
 override-dependencies = [
-    "cryptography>=48.0.1",
+    "cryptography>=50.0.0",
 ]
 exclude-newer = "7 days"


### PR DESCRIPTION
This PR upgrades `cryptography` in `pyproject.toml` to `>=50.0.0` to resolve high-severity vulnerability CVE-2026-69247 (PKCS#7 EnvelopedData decryption Bleichenbacher oracle).